### PR TITLE
Logout listener bug fix

### DIFF
--- a/src/Listeners/LogoutListener.php
+++ b/src/Listeners/LogoutListener.php
@@ -21,7 +21,7 @@ class LogoutListener
             $user = $event->user;
             $ip = $this->request->ip();
             $userAgent = $this->request->userAgent();
-            $log = $user->authentications()->whereIpAddress($ip)->whereUserAgent($userAgent)->first();
+            $log = $user->authentications()->whereIpAddress($ip)->whereUserAgent($userAgent)->orderByDesc('login_at')->first();
 
             if (! $log) {
                 $log = new AuthenticationLog([


### PR DESCRIPTION
This should remedy and close the following bug: 

#8 -  The Logout listener was grabbing the first record instead of the latest, causes records to not be updated on logout 