### PR TITLE
Added extra where clause to known variable

### DIFF
--- a/src/Listeners/LoginListener.php
+++ b/src/Listeners/LoginListener.php
@@ -22,7 +22,7 @@ class LoginListener
             $user = $event->user;
             $ip = $this->request->ip();
             $userAgent = $this->request->userAgent();
-            $known = $user->authentications()->whereIpAddress($ip)->whereUserAgent($userAgent)->where('login_successful', true)->first();
+            $known = $user->authentications()->whereIpAddress($ip)->whereUserAgent($userAgent)->whereLoginSuccessful(true)->first();
             $newUser = Carbon::parse($user->{$user->getCreatedAtColumn()})->diffInMinutes(Carbon::now()) < 1;
 
             $log = $user->authentications()->create([

--- a/src/Listeners/LoginListener.php
+++ b/src/Listeners/LoginListener.php
@@ -22,7 +22,7 @@ class LoginListener
             $user = $event->user;
             $ip = $this->request->ip();
             $userAgent = $this->request->userAgent();
-            $known = $user->authentications()->whereIpAddress($ip)->whereUserAgent($userAgent)->first();
+            $known = $user->authentications()->whereIpAddress($ip)->whereUserAgent($userAgent)->where('login_successful', true)->first();
             $newUser = Carbon::parse($user->{$user->getCreatedAtColumn()})->diffInMinutes(Carbon::now()) < 1;
 
             $log = $user->authentications()->create([


### PR DESCRIPTION
Checked for a successful login only.

When a failed login attempt happens the user can receive a notification stating it failed. However, if that same device then successfully signs in the user is not informed about the successful login. From a security stand point the user doesn't know that the bad actor gained access after a failed attempt.