### PR TITLE
Fix Dependency Injection to Avoid Syntax Error.

### DIFF
--- a/src/Listeners/FailedLoginListener.php
+++ b/src/Listeners/FailedLoginListener.php
@@ -8,7 +8,12 @@ use Rappasoft\LaravelAuthenticationLog\Notifications\FailedLogin;
 
 class FailedLoginListener
 {
-    public Request $request;
+    /**
+     * The request.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
 
     public function __construct(Request $request)
     {

--- a/src/Listeners/LoginListener.php
+++ b/src/Listeners/LoginListener.php
@@ -9,7 +9,12 @@ use Rappasoft\LaravelAuthenticationLog\Notifications\NewDevice;
 
 class LoginListener
 {
-    public Request $request;
+    /**
+     * The request.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
 
     public function __construct(Request $request)
     {

--- a/src/Listeners/LogoutListener.php
+++ b/src/Listeners/LogoutListener.php
@@ -8,7 +8,12 @@ use Rappasoft\LaravelAuthenticationLog\Models\AuthenticationLog;
 
 class LogoutListener
 {
-    public Request $request;
+    /**
+     * The request.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
 
     public function __construct(Request $request)
     {

--- a/src/Listeners/OtherDeviceLogoutListener.php
+++ b/src/Listeners/OtherDeviceLogoutListener.php
@@ -8,7 +8,12 @@ use Rappasoft\LaravelAuthenticationLog\Models\AuthenticationLog;
 
 class OtherDeviceLogoutListener
 {
-    public Request $request;
+    /**
+     * The request.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
 
     public function __construct(Request $request)
     {

--- a/src/Notifications/FailedLogin.php
+++ b/src/Notifications/FailedLogin.php
@@ -14,7 +14,12 @@ class FailedLogin extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    public AuthenticationLog $authenticationLog;
+    /**
+     * The request.
+     *
+     * @var \Rappasoft\LaravelAuthenticationLog\Models\AuthenticationLog
+     */
+    public $authenticationLog;
 
     public function __construct(AuthenticationLog $authenticationLog)
     {

--- a/src/Notifications/NewDevice.php
+++ b/src/Notifications/NewDevice.php
@@ -14,7 +14,12 @@ class NewDevice extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    public AuthenticationLog $authenticationLog;
+    /**
+     * The request.
+     *
+     * @var \Rappasoft\LaravelAuthenticationLog\Models\AuthenticationLog
+     */
+    public $authenticationLog;
 
     public function __construct(AuthenticationLog $authenticationLog)
     {


### PR DESCRIPTION
A Class Properties should be 'String' or 'Constant' just to avoid "Syntax Error".