### PR TITLE
Modified to work with PHP 7.4

### DIFF
--- a/src/LaravelAuthenticationLogServiceProvider.php
+++ b/src/LaravelAuthenticationLogServiceProvider.php
@@ -27,9 +27,9 @@ class LaravelAuthenticationLogServiceProvider extends PackageServiceProvider
             ->hasCommand(PurgeAuthenticationLogCommand::class);
 
         $events = $this->app->make(Dispatcher::class);
-        $events->listen(config('authentication-log.events.login') ?? Login::class, LoginListener::class);
-        $events->listen(config('authentication-log.events.failed') ?? Failed::class, FailedLoginListener::class);
-        $events->listen(config('authentication-log.events.logout') ?? Logout::class, LogoutListener::class);
-        $events->listen(config('authentication-log.events.other-device-logout') ?? OtherDeviceLogout::class, OtherDeviceLogoutListener::class);
+        $events->listen(config('authentication-log.events.login', Login::class), LoginListener::class);
+        $events->listen(config('authentication-log.events.failed', Failed::class), FailedLoginListener::class);
+        $events->listen(config('authentication-log.events.logout', Logout::class), LogoutListener::class);
+        $events->listen(config('authentication-log.events.other-device-logout', OtherDeviceLogout::class), OtherDeviceLogoutListener::class);
     }
 }

--- a/src/Listeners/FailedLoginListener.php
+++ b/src/Listeners/FailedLoginListener.php
@@ -17,7 +17,8 @@ class FailedLoginListener
 
     public function handle($event): void
     {
-        if (! $event instanceof (config('authentication-log.events.failed') ?? Failed::class)) {
+        $listener = config('authentication-log.events.failed', Failed::class);
+        if (! $event instanceof $listener) {
             return;
         }
 

--- a/src/Listeners/LoginListener.php
+++ b/src/Listeners/LoginListener.php
@@ -18,7 +18,8 @@ class LoginListener
 
     public function handle($event): void
     {
-        if (! $event instanceof (config('authentication-log.events.login') ?? Login::class)) {
+        $listener = config('authentication-log.events.login', Login::class);
+        if (! $event instanceof $listener) {
             return;
         }
 

--- a/src/Listeners/LogoutListener.php
+++ b/src/Listeners/LogoutListener.php
@@ -17,7 +17,8 @@ class LogoutListener
 
     public function handle($event): void
     {
-        if (! $event instanceof (config('authentication-log.events.logout') ?? Logout::class)) {
+        $listener = config('authentication-log.events.logout', Logout::class);
+        if (! $event instanceof $listener) {
             return;
         }
 

--- a/src/Listeners/OtherDeviceLogoutListener.php
+++ b/src/Listeners/OtherDeviceLogoutListener.php
@@ -17,7 +17,8 @@ class OtherDeviceLogoutListener
 
     public function handle($event): void
     {
-        if (! $event instanceof (config('authentication-log.events.other-device-logout') ?? OtherDeviceLogout::class)) {
+        $listener = config('authentication-log.events.other-device-logout', OtherDeviceLogout::class);
+        if (! $event instanceof $listener) {
             return;
         }
 


### PR DESCRIPTION
PHP 7.4 doesn't allow the use of `??` with a function call so this change is a little more verbose but works. It also makes use of the `config()` function's `$default` parameter.