### PR TITLE
Implementing latestAuthentication() relation

### DIFF
--- a/src/Traits/AuthenticationLoggable.php
+++ b/src/Traits/AuthenticationLoggable.php
@@ -11,6 +11,11 @@ trait AuthenticationLoggable
         return $this->morphMany(AuthenticationLog::class, 'authenticatable')->latest('login_at');
     }
 
+    public function latestAuthentication()
+    {
+        return $this->morphOne(AuthenticationLog::class, 'authenticatable')->latestOfMany('login_at');
+    }
+
     public function notifyAuthenticationLogVia(): array
     {
         return ['mail'];


### PR DESCRIPTION
Latest authentication relation is OneOfMany type relation which will return the latest authentication data.

Useful for retrieving multiple users with eager loaded relation of last login data without having to deal with huge collections of past logins.