### PR TITLE
Fixed issue with getting previous login at and previous login IP.

### DIFF
--- a/src/Traits/AuthenticationLoggable.php
+++ b/src/Traits/AuthenticationLoggable.php
@@ -43,11 +43,11 @@ trait AuthenticationLoggable
 
     public function previousLoginAt()
     {
-        return optional($this->authentications()->skip(1)->where('login_successful', true)->first())->login_at;
+        return optional($this->authentications()->skip(1)->whereLoginSuccessful(true)->first())->login_at;
     }
 
     public function previousLoginIp()
     {
-        return optional($this->authentications()->skip(1)->where('login_successful', true)->first())->ip_address;
+        return optional($this->authentications()->skip(1)->whereLoginSuccessful(true)->first())->ip_address;
     }
 }

--- a/src/Traits/AuthenticationLoggable.php
+++ b/src/Traits/AuthenticationLoggable.php
@@ -43,11 +43,11 @@ trait AuthenticationLoggable
 
     public function previousLoginAt()
     {
-        return optional($this->authentications()->skip(1)->first())->login_at;
+        return optional($this->authentications()->skip(1)->where('login_successful', true)->first())->login_at;
     }
 
     public function previousLoginIp()
     {
-        return optional($this->authentications()->skip(1)->first())->ip_address;
+        return optional($this->authentications()->skip(1)->where('login_successful', true)->first())->ip_address;
     }
 }


### PR DESCRIPTION
When using:
```php
auth()->user()->previousLoginAt();
// or
auth()->user()->previousLoginIp();
```
They currently do not skip ALL failed login attempts.

For instance, if there is a failed login attempt prior to the current successful login, it will retrieve and return the failed login details.

With this pull request it will fix that issue and skip the failed login attempts and give the true successful previous login.