### PR TITLE
Optimize Other Devices Logout Listener

### DIFF
--- a/src/Listeners/OtherDeviceLogoutListener.php
+++ b/src/Listeners/OtherDeviceLogoutListener.php
@@ -35,7 +35,7 @@ class OtherDeviceLogoutListener
                 ]);
             }
 
-            foreach ($user->authentications()->whereLoginSuccessful(true)->get() as $log) {
+            foreach ($user->authentications()->whereLoginSuccessful(true)->whereNull('logout_at')->get() as $log) {
                 if ($log->id !== $authenticationLog->id) {
                     $log->update([
                         'cleared_by_user' => true,


### PR DESCRIPTION
Currently, when logging out of other devices, the listener updates every record for the given user, on a large dataset this can be hundreds of queries.
By limiting the scope of the records to only the ones that are not logged out, the number of queries is reduced to a minimum amount.