### PR TITLE
Added PHPDocs to allow autocompletion in IDE

### DIFF
--- a/src/Models/AuthenticationLog.php
+++ b/src/Models/AuthenticationLog.php
@@ -5,6 +5,18 @@ namespace Rappasoft\LaravelAuthenticationLog\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
+/**
+ * @property int $id
+ * @property string $authenticatable_type
+ * @property int $authenticatable_id
+ * @property string|null $ip_address
+ * @property string|null $user_agent
+ * @property \Illuminate\Support\Carbon|null $login_at
+ * @property bool $login_successful
+ * @property \Illuminate\Support\Carbon|null $logout_at
+ * @property bool $cleared_by_user
+ * @property array|null $location
+ */
 class AuthenticationLog extends Model
 {
     public $timestamps = false;


### PR DESCRIPTION
Hi There. Thanks for this package, we've just started using it. I saw it was missing PHPDoc blocks for the properties on the model. I like to let me IDE do as much thinking for me as possible. 

We had a scenario where our project needed to report on how many people logged in on each day for 3 months and doing $log-> didn't show any values in my IDE. So thought i'd do a PR. 

```
$user->authentications()
        ->where('login_at', '>', Carbon::now()->subMonthsNoOverflow(3))
        ->get()
        ->countBy(function(AuthenticationLog $log) {
            return $log->login_at->timezone(Tenancy::getTenant()->timezone)->format('Ymd');
        });
```