### PR TITLE
Make configurable the number of minutes after which the user is no longer considered a new user.

### DIFF
--- a/config/authentication-log.php
+++ b/config/authentication-log.php
@@ -26,6 +26,9 @@ return [
 
             // The Notification class to send
             'template' => \Rappasoft\LaravelAuthenticationLog\Notifications\NewDevice::class,
+
+            // Number of minutes after which the user is no longer considered as a new user
+            'new_user_in_minutes' => env('NEW_USER_IN_MINUTES', 1),
         ],
         'failed-login' => [
             // Send the FailedLogin notification

--- a/src/Listeners/LoginListener.php
+++ b/src/Listeners/LoginListener.php
@@ -27,8 +27,6 @@ class LoginListener
             $user = $event->user;
             $ip = $this->request->ip();
             $userAgent = $this->request->userAgent();
-            $known = $user->authentications()->whereIpAddress($ip)->whereUserAgent($userAgent)->whereLoginSuccessful(true)->first();
-            $newUser = Carbon::parse($user->{$user->getCreatedAtColumn()})->diffInMinutes(Carbon::now()) < config('authentication-log.notifications.new-device.new_user_in_minutes', 1);
 
             $log = $user->authentications()->create([
                 'ip_address' => $ip,
@@ -38,7 +36,14 @@ class LoginListener
                 'location' => config('authentication-log.notifications.new-device.location') ? optional(geoip()->getLocation($ip))->toArray() : null,
             ]);
 
-            if (! $known && ! $newUser && config('authentication-log.notifications.new-device.enabled')) {
+            if (empty(config('authentication-log.notifications.new-device.enabled'))) {
+                return;
+            }
+
+            $known = $user->authentications()->whereIpAddress($ip)->whereUserAgent($userAgent)->whereLoginSuccessful(true)->first();
+            $newUser = Carbon::parse($user->{$user->getCreatedAtColumn()})->diffInMinutes(Carbon::now()) < config('authentication-log.notifications.new-device.new_user_in_minutes', 1);
+
+            if (! $known && ! $newUser) {
                 $newDevice = config('authentication-log.notifications.new-device.template') ?? NewDevice::class;
                 $user->notify(new $newDevice($log));
             }

--- a/src/Listeners/LoginListener.php
+++ b/src/Listeners/LoginListener.php
@@ -28,7 +28,7 @@ class LoginListener
             $ip = $this->request->ip();
             $userAgent = $this->request->userAgent();
             $known = $user->authentications()->whereIpAddress($ip)->whereUserAgent($userAgent)->whereLoginSuccessful(true)->first();
-            $newUser = Carbon::parse($user->{$user->getCreatedAtColumn()})->diffInMinutes(Carbon::now()) < 1;
+            $newUser = Carbon::parse($user->{$user->getCreatedAtColumn()})->diffInMinutes(Carbon::now()) < config('authentication-log.notifications.new-device.new_user_in_minutes', 1);
 
             $log = $user->authentications()->create([
                 'ip_address' => $ip,


### PR DESCRIPTION
Users often connect from different devices (desktop, mobile, tablet, etc.) and from different locations (home, work, etc.). If we send notifications to users more than a minute old, we will generate a lot of false positives.

A simple solution would be to make the number of minutes after which a user is no longer considered a new user configurable in order to increase that time.

In my case, increasing that amount to a week (60 * 24 * 7) or a month (60 * 24 * 30) would greatly reduce false positives.

Thank you very much.