### PR TITLE
Check if the model correctly implements the trait.

### DIFF
--- a/src/Listeners/LoginListener.php
+++ b/src/Listeners/LoginListener.php
@@ -6,6 +6,7 @@ use Illuminate\Auth\Events\Login;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Rappasoft\LaravelAuthenticationLog\Notifications\NewDevice;
+use Rappasoft\LaravelAuthenticationLog\Traits\AuthenticationLoggable;
 
 class LoginListener
 {
@@ -24,6 +25,9 @@ class LoginListener
         }
 
         if ($event->user) {
+            if(!in_array(AuthenticationLoggable::class, class_uses_recursive(get_class($event->user))){
+                return;
+            }
             $user = $event->user;
             $ip = $this->request->ip();
             $userAgent = $this->request->userAgent();


### PR DESCRIPTION
In my auth.php I got multiple guards example:
```
    'guards' => [
        'web' => [
            'driver'   => 'session',
            'provider' => 'users',
        ],

        'member' => [
            'driver'   => 'session',
            'provider' => 'members',
.....
```

For now I only want to log the users data so I applied the trait to the User::class. Now when logging in as member. I get the following error: call to undefined method App\Models\Member::authentications(). This is because my Member::class does not have the trait implemented. There is no way to configure this either. So I added this check. I could add it do all the listeners or do you rather have a config with the classes into it that should be logged?