### PR TITLE
Fix log creation in the LogoutListener to use correct class

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![GitHub Code Style Action Status](https://img.shields.io/github/workflow/status/rappasoft/laravel-authentication-log/Check%20&%20fix%20styling?label=code%20style)](https://github.com/rappasoft/laravel-authentication-log/actions?query=workflow%3A"Check+%26+fix+styling"+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/rappasoft/laravel-authentication-log.svg?style=flat-square)](https://packagist.org/packages/rappasoft/laravel-authentication-log)
 
-### Enjoying this package? [Buy me a beer 🍺](https://www.buymeacoffee.com/rappasoft)
-
 Laravel Authentication Log is a package which tracks your user's authentication information such as login/logout time, IP, Browser, Location, etc. as well as sends out notifications via mail, slack, or sms for new devices and failed logins.
 
 ## Documentation, Installation, and Usage Instructions

--- a/src/Listeners/LogoutListener.php
+++ b/src/Listeners/LogoutListener.php
@@ -41,7 +41,7 @@ class LogoutListener
             $log = $user->authentications()->whereIpAddress($ip)->whereUserAgent($userAgent)->orderByDesc('login_at')->first();
 
             if (! $log) {
-                $log = new AuthenticationLog([
+                $log = $user->authentications()->create([
                     'ip_address' => $ip,
                     'user_agent' => $userAgent,
                 ]);


### PR DESCRIPTION
It is possible to use a custom `AuthenticationLog` by overriding the `authentications()` and `latestAuthentication()` methods from the `AuthenticationLoggable` trait, except for this listener which tries creates a new `AuthenticationLog` directly. By going through the User model, we will create an object of the correct (custom) class.

This fixes the specific problem of a custom `AuthenticationLog` model that uses the `\Illuminate\Database\Eloquent\Concerns \hasUlids` trait not being successfully created here because it fails to generate the id.