### PR TITLE
remove hardcoded config entries in the service provider

### DIFF
--- a/src/LaravelAuthenticationLogServiceProvider.php
+++ b/src/LaravelAuthenticationLogServiceProvider.php
@@ -28,9 +28,10 @@ class LaravelAuthenticationLogServiceProvider extends PackageServiceProvider
             ->hasCommand(PurgeAuthenticationLogCommand::class);
 
         $events = $this->app->make(Dispatcher::class);
-        $events->listen(config('authentication-log.events.login', Login::class), config('authentication-log.listeners.login', LoginListener::class));
-        $events->listen(config('authentication-log.events.failed', Failed::class), config('authentication-log.listeners.failed', FailedLoginListener::class));
-        $events->listen(config('authentication-log.events.logout', Logout::class), config('authentication-log.listeners.logout', LogoutListener::class));
-        $events->listen(config('authentication-log.events.other-device-logout', OtherDeviceLogout::class), config('authentication-log.listeners.other-device-logout', OtherDeviceLogoutListener::class));
+        $eventKeys = array_keys(config("authentication-log.events"));
+        foreach ($eventKeys as $key) {
+         $events->listen(config("authentication-log.events")[$key], config("authentication-log.listeners")[$key]);
+        }
+
     }
 }


### PR DESCRIPTION
remove hardcoded config entries in the service provider, so that events listed in config are automatically listening. 

Tested using PHP8.4 & Laravel 10.48.29