### PR TITLE
Fixed default value when state location value is not available

### DIFF
--- a/resources/views/emails/failed.blade.php
+++ b/resources/views/emails/failed.blade.php
@@ -8,7 +8,7 @@
 > **@lang('IP Address:')** {{ $ipAddress }}<br/>
 > **@lang('Browser:')** {{ $browser }}<br/>
 @if ($location && $location['default'] === false)
-> **@lang('Location:')** {{ $location['city'] ?? __('Unknown City') }}, {{ $location['state'], __('Unknown State') }}
+> **@lang('Location:')** {{ $location['city'] ?? __('Unknown City') }}, {{ $location['state'] ?? __('Unknown State') }}
 @endif
 
 @lang('If this was you, you can ignore this alert. If you suspect any suspicious activity on your account, please change your password.')

--- a/resources/views/emails/new.blade.php
+++ b/resources/views/emails/new.blade.php
@@ -8,7 +8,7 @@
 > **@lang('IP Address:')** {{ $ipAddress }}<br/>
 > **@lang('Browser:')** {{ $browser }}<br/>
 @if ($location && $location['default'] === false)
-> **@lang('Location:')** {{ $location['city'] ?? __('Unknown City') }}, {{ $location['state'], __('Unknown State') }}
+> **@lang('Location:')** {{ $location['city'] ?? __('Unknown City') }}, {{ $location['state'] ?? __('Unknown State') }}
 @endif
 
 @lang('If this was you, you can ignore this alert. If you suspect any suspicious activity on your account, please change your password.')


### PR DESCRIPTION
Changed location state value from
```php
{{ $location['state'], __('Unknown State') }}

```
to
```php
{{ $location['state'] ?? __('Unknown State') }}
```
in both emails