### PR TITLE
Use location from failed-login not new-device config

### DIFF
--- a/src/Listeners/FailedLoginListener.php
+++ b/src/Listeners/FailedLoginListener.php
@@ -40,7 +40,7 @@ class FailedLoginListener
                 'user_agent' => $this->request->userAgent(),
                 'login_at' => now(),
                 'login_successful' => false,
-                'location' => config('authentication-log.notifications.new-device.location') ? optional(geoip()->getLocation($ip))->toArray() : null,
+                'location' => config('authentication-log.notifications.failed-login.location') ? optional(geoip()->getLocation($ip))->toArray() : null,
             ]);
 
             if (config('authentication-log.notifications.failed-login.enabled')) {


### PR DESCRIPTION
src/Listeners/FailedLoginListener.php currently references 
```
config('authentication-log.notifications.new-device.location')
```
This amends to use
```
config('authentication-log.notifications.failed-login.location')
```