### PR TITLE
use Event facade instead of manual Dispatcher resolution

### DIFF
--- a/src/LaravelAuthenticationLogServiceProvider.php
+++ b/src/LaravelAuthenticationLogServiceProvider.php
@@ -6,7 +6,7 @@ use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Auth\Events\OtherDeviceLogout;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Facades\Event;
 use Rappasoft\LaravelAuthenticationLog\Commands\PurgeAuthenticationLogCommand;
 use Rappasoft\LaravelAuthenticationLog\Listeners\FailedLoginListener;
 use Rappasoft\LaravelAuthenticationLog\Listeners\LoginListener;
@@ -27,10 +27,9 @@ class LaravelAuthenticationLogServiceProvider extends PackageServiceProvider
             ->hasMigration('create_authentication_log_table')
             ->hasCommand(PurgeAuthenticationLogCommand::class);
 
-        $events = $this->app->make(Dispatcher::class);
-        $events->listen(config('authentication-log.events.login', Login::class), config('authentication-log.listeners.login', LoginListener::class));
-        $events->listen(config('authentication-log.events.failed', Failed::class), config('authentication-log.listeners.failed', FailedLoginListener::class));
-        $events->listen(config('authentication-log.events.logout', Logout::class), config('authentication-log.listeners.logout', LogoutListener::class));
-        $events->listen(config('authentication-log.events.other-device-logout', OtherDeviceLogout::class), config('authentication-log.listeners.other-device-logout', OtherDeviceLogoutListener::class));
+        Event::listen(config('authentication-log.events.login', Login::class), config('authentication-log.listeners.login', LoginListener::class));
+        Event::listen(config('authentication-log.events.failed', Failed::class), config('authentication-log.listeners.failed', FailedLoginListener::class));
+        Event::listen(config('authentication-log.events.logout', Logout::class), config('authentication-log.listeners.logout', LogoutListener::class));
+        Event::listen(config('authentication-log.events.other-device-logout', OtherDeviceLogout::class), config('authentication-log.listeners.other-device-logout', OtherDeviceLogoutListener::class));
     }
 }


### PR DESCRIPTION
Straight forward enough, but it uses the Event Facade rather than manually retrieving the dispatcher class, which I think improves clarity. Under the hood its the same afaik. May be nicer to put them in a method, but leaving as is for now.

Replaces `$this->app->make(Dispatcher::class)->listen()` with `Event::listen()`   

Feel free to close if you don't prefer it, but seems to be the norm now. [Here's some examples](https://github.com/laravel/folio/blob/45d9c81c20bfd370ff1973323a6dd0f085612f69/src/FolioServiceProvider.php#L94).

Alternative is `app('events')`