### PR TITLE
fix : Logout Listener order by being called twice

### DIFF
--- a/src/Listeners/LogoutListener.php
+++ b/src/Listeners/LogoutListener.php
@@ -38,7 +38,7 @@ class LogoutListener
             }
 
             $userAgent = $this->request->userAgent();
-            $log = $user->authentications()->whereIpAddress($ip)->whereUserAgent($userAgent)->orderByDesc('login_at')->first();
+            $log = $user->authentications()->whereIpAddress($ip)->whereUserAgent($userAgent)->first();
 
             if (! $log) {
                 $log = new AuthenticationLog([


### PR DESCRIPTION
Closes https://github.com/rappasoft/laravel-authentication-log/issues/111, https://github.com/rappasoft/laravel-authentication-log/issues/87 and https://github.com/rappasoft/laravel-authentication-log/issues/48

The authentications relationship [already calls latest()](https://github.com/rappasoft/laravel-authentication-log/blob/9389b44eb42caf044d8e1d1adc59f049a897f2b3/src/Traits/AuthenticationLoggable.php#L11) so we don't need to add an orderBy here.

Because it calls latest, It already calls order by login_at desc [thanks to this](https://github.com/laravel/framework/blob/c0955af55f216ba0b864a3819acb435859957f0a/src/Illuminate/Database/Query/Builder.php#L2669) - and the query builder ensures the order by is at the end.