### PR TITLE
Add `use $tableName` for the upgrade down migration

### DIFF
--- a/database/migrations/add_new_features_to_authentication_log_table.php.stub
+++ b/database/migrations/add_new_features_to_authentication_log_table.php.stub
@@ -66,7 +66,7 @@ return new class extends Migration
             return;
         }
 
-        Schema::table($tableName, function (Blueprint $table) {
+        Schema::table($tableName, function (Blueprint $table) use ($tableName) {
             $columns = [
                 'device_id',
                 'device_name',


### PR DESCRIPTION
The down migration was missing the `use ($tableName)` that the `up()` parts of the migration were doing, ending up with `$tableName` being undefined, which would result in none of the columns being dropped. This fixes that.