### PR TITLE
Add compatibility for changes to Laravel starter kits and default model date casting

### DIFF
--- a/src/Models/AuthenticationLog.php
+++ b/src/Models/AuthenticationLog.php
@@ -15,10 +15,10 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * @property string|null $device_id
  * @property string|null $device_name
  * @property bool $is_trusted
- * @property \Illuminate\Support\Carbon|null $login_at
+ * @property \Carbon\CarbonInterface|null $login_at
  * @property bool $login_successful
- * @property \Illuminate\Support\Carbon|null $logout_at
- * @property \Illuminate\Support\Carbon|null $last_activity_at
+ * @property \Carbon\CarbonInterface|null $logout_at
+ * @property \Carbon\CarbonInterface|null $last_activity_at
  * @property bool $cleared_by_user
  * @property array|null $location
  * @property bool $is_suspicious

--- a/src/Traits/AuthenticationLoggable.php
+++ b/src/Traits/AuthenticationLoggable.php
@@ -23,12 +23,12 @@ trait AuthenticationLoggable
         return ['mail'];
     }
 
-    public function lastLoginAt(): ?\Illuminate\Support\Carbon
+    public function lastLoginAt(): ?\Carbon\CarbonInterface
     {
         return $this->authentications()->first()?->login_at;
     }
 
-    public function lastSuccessfulLoginAt(): ?\Illuminate\Support\Carbon
+    public function lastSuccessfulLoginAt(): ?\Carbon\CarbonInterface
     {
         return $this->authentications()->whereLoginSuccessful(true)->first()?->login_at;
     }
@@ -43,7 +43,7 @@ trait AuthenticationLoggable
         return $this->authentications()->whereLoginSuccessful(true)->first()?->ip_address;
     }
 
-    public function previousLoginAt(): ?\Illuminate\Support\Carbon
+    public function previousLoginAt(): ?\Carbon\CarbonInterface
     {
         return $this->authentications()->skip(1)->first()?->login_at;
     }

--- a/tests/Unit/AuthenticationLoggableTraitTest.php
+++ b/tests/Unit/AuthenticationLoggableTraitTest.php
@@ -36,7 +36,7 @@ it('can get last login at', function () {
     ]);
 
     expect($user->lastLoginAt())->not->toBeNull();
-    expect($user->lastLoginAt())->toBeInstanceOf(\Illuminate\Support\Carbon::class);
+    expect($user->lastLoginAt())->toBeInstanceOf(\Carbon\CarbonInterface::class);
 });
 
 it('returns null when no authentications exist', function () {


### PR DESCRIPTION
Add compatibility with changes to `AppServiceProvider` in [Vue](https://github.com/laravel/vue-starter-kit/commit/efe2726388269a825fc639cc3f729768eeda57dc), [Livewire](https://github.com/laravel/livewire-starter-kit/commit/36b01d6a0eaf29b57eb2802c71a293f703b90073), and [React](https://github.com/laravel/react-starter-kit/blame/main/app/Providers/AppServiceProvider.php) starter kits that make dates cast from models to return `CarbonImmutable` instances rather than `Carbon` by default.

Fixes issue where methods that return `Carbon` objects in `AuthenticationLoggable` would cause a `TypeError`. Methods are compatible with `Carbon` and `CarbonImmutable` return types.