### PR TITLE
v6.1.0 - Laravel 13 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .php_cs
 .php_cs.cache
 .phpunit.result.cache
+.phpunit.cache
 build
 composer.lock
 coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `Laravel Authentication Log` will be documented in this file.
 
+### 6.1.0 - 2026-06-10
+
+#### Added
+- Laravel 13.x support (#138, #140)
+- Regression test covering applications that use immutable date casting
+
+#### Changed
+- `lastLoginAt()`, `lastSuccessfulLoginAt()`, and `previousLoginAt()` now return `\Carbon\CarbonInterface` instead of `\Illuminate\Support\Carbon`, fixing a `TypeError` in applications that cast model dates to `CarbonImmutable` — the default in the current Laravel starter kits (#137)
+- PHP 8.2+ is now required (PHP 8.1 is EOL, and no Laravel version supported by this package runs on it)
+- Modernized the PHPUnit configuration for PHPUnit 10+ and updated the CI matrix (PHP 8.2–8.4, Laravel 11.x–13.x)
+
+### 6.0.1 - 2025-12-08
+
+#### Fixed
+- The upgrade migration's `down()` method now respects the configured table name (#135, #136)
+
 ### 6.0.0 - 2025-01-27
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ See the [documentation](https://rappasoft.com/docs/laravel-authentication-log) f
  10.x     | 3.x               | Basic logging only
  11.x     | 5.x, 6.x          | All features (device fingerprinting, suspicious activity, webhooks, session management, etc.)
  12.x     | 5.x, 6.x          | All features (device fingerprinting, suspicious activity, webhooks, session management, etc.)
+ 13.x     | 6.1+              | All features (device fingerprinting, suspicious activity, webhooks, session management, etc.)
 
-**Note:** Version 6.x requires Laravel 11.x or 12.x and PHP 8.1+. Version 5.x also supports Laravel 11.x and 12.x. For Laravel 10.x support, please use version 3.x.
+**Note:** Version 6.1+ requires Laravel 11.x, 12.x, or 13.x and PHP 8.2+. Version 5.x also supports Laravel 11.x and 12.x. For Laravel 10.x support, please use version 3.x.
 
 ## Installation
 

--- a/docs/start/installation.md
+++ b/docs/start/installation.md
@@ -5,8 +5,8 @@ weight: 1
 
 ## Requirements
 
-- PHP 8.1 or higher
-- Laravel 11.x or 12.x
+- PHP 8.2 or higher
+- Laravel 11.x, 12.x, or 13.x
 
 **Note:** For Laravel 10.x support, please use version 3.x of this package.
 

--- a/docs/start/upgrade.md
+++ b/docs/start/upgrade.md
@@ -63,7 +63,7 @@ The following columns will be added to your `authentication_log` table:
 
 ## Requirements
 
-**Version 6.x requires Laravel 11.x or 12.x.**
+**Version 6.x requires Laravel 11.x, 12.x, or 13.x.** (Laravel 13.x support requires version 6.1+ and PHP 8.2+.)
 
 If you're still using Laravel 10.x, please continue using version 5.x of this package. Version 6.x is a major release that drops support for Laravel 10.x to simplify the codebase and take advantage of Laravel 11+ features.
 
@@ -108,7 +108,7 @@ This is **expected behavior**. Only new authentication logs created after the up
    ```bash
    php artisan --version
    ```
-   New features require Laravel 11.x or 12.x.
+   New features require Laravel 11.x, 12.x, or 13.x.
 
 2. **Verify migrations ran successfully:**
    ```bash

--- a/src/Models/AuthenticationLog.php
+++ b/src/Models/AuthenticationLog.php
@@ -15,10 +15,10 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * @property string|null $device_id
  * @property string|null $device_name
  * @property bool $is_trusted
- * @property \Illuminate\Support\Carbon|null $login_at
+ * @property \Carbon\CarbonInterface|null $login_at
  * @property bool $login_successful
- * @property \Illuminate\Support\Carbon|null $logout_at
- * @property \Illuminate\Support\Carbon|null $last_activity_at
+ * @property \Carbon\CarbonInterface|null $logout_at
+ * @property \Carbon\CarbonInterface|null $last_activity_at
  * @property bool $cleared_by_user
  * @property array|null $location
  * @property bool $is_suspicious

--- a/src/Traits/AuthenticationLoggable.php
+++ b/src/Traits/AuthenticationLoggable.php
@@ -23,12 +23,12 @@ trait AuthenticationLoggable
         return ['mail'];
     }
 
-    public function lastLoginAt(): ?\Illuminate\Support\Carbon
+    public function lastLoginAt(): ?\Carbon\CarbonInterface
     {
         return $this->authentications()->first()?->login_at;
     }
 
-    public function lastSuccessfulLoginAt(): ?\Illuminate\Support\Carbon
+    public function lastSuccessfulLoginAt(): ?\Carbon\CarbonInterface
     {
         return $this->authentications()->whereLoginSuccessful(true)->first()?->login_at;
     }
@@ -43,7 +43,7 @@ trait AuthenticationLoggable
         return $this->authentications()->whereLoginSuccessful(true)->first()?->ip_address;
     }
 
-    public function previousLoginAt(): ?\Illuminate\Support\Carbon
+    public function previousLoginAt(): ?\Carbon\CarbonInterface
     {
         return $this->authentications()->skip(1)->first()?->login_at;
     }

--- a/tests/Unit/AuthenticationLoggableTraitTest.php
+++ b/tests/Unit/AuthenticationLoggableTraitTest.php
@@ -36,7 +36,7 @@ it('can get last login at', function () {
     ]);
 
     expect($user->lastLoginAt())->not->toBeNull();
-    expect($user->lastLoginAt())->toBeInstanceOf(\Illuminate\Support\Carbon::class);
+    expect($user->lastLoginAt())->toBeInstanceOf(\Carbon\CarbonInterface::class);
 });
 
 it('returns null when no authentications exist', function () {

--- a/tests/Unit/AuthenticationLoggableTraitTest.php
+++ b/tests/Unit/AuthenticationLoggableTraitTest.php
@@ -71,3 +71,22 @@ it('can get last successful login ip', function () {
 
     expect($user->lastSuccessfulLoginIp())->toBe('192.168.1.2');
 });
+
+it('supports applications using immutable date casting', function () {
+    \Illuminate\Support\Facades\Date::use(\Carbon\CarbonImmutable::class);
+
+    try {
+        $user = TestUser::factory()->create();
+
+        AuthenticationLog::factory()->create([
+            'authenticatable_type' => get_class($user),
+            'authenticatable_id' => $user->id,
+            'login_at' => now()->subDay(),
+        ]);
+
+        expect($user->lastLoginAt())->toBeInstanceOf(\Carbon\CarbonImmutable::class);
+        expect($user->lastSuccessfulLoginAt())->toBeInstanceOf(\Carbon\CarbonImmutable::class);
+    } finally {
+        \Illuminate\Support\Facades\Date::useDefault();
+    }
+});

--- a/tests/Unit/AuthenticationLoggableTraitTest.php
+++ b/tests/Unit/AuthenticationLoggableTraitTest.php
@@ -82,6 +82,7 @@ it('supports applications using immutable date casting', function () {
             'authenticatable_type' => get_class($user),
             'authenticatable_id' => $user->id,
             'login_at' => now()->subDay(),
+            'login_successful' => true,
         ]);
 
         expect($user->lastLoginAt())->toBeInstanceOf(\Carbon\CarbonImmutable::class);


### PR DESCRIPTION
## What's Changed

* Laravel 13.x support (#140 by @fdemb, supersedes #138) — CI matrix now covers PHP 8.2–8.4 on Laravel 11.x/12.x/13.x
* Immutable date casting compatibility (#137 by @SkyLundy) — `lastLoginAt()`, `lastSuccessfulLoginAt()`, and `previousLoginAt()` now return `\Carbon\CarbonInterface`, fixing a `TypeError` for apps using `CarbonImmutable` (the default in current Laravel starter kits)
* New regression test covering immutable date casting
* Docs and changelog updated for Laravel 13 / PHP 8.2+

🤖 Generated with [Claude Code](https://claude.com/claude-code)