### PR TITLE
Documentation updates for v6.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Laravel Authentication Log is a comprehensive package which tracks your user's authentication information such as login/logout time, IP, Browser, Location, Device Fingerprint, etc. It sends out notifications via mail, slack, or SMS for new devices and failed logins, detects suspicious activity, provides session management, prevents duplicate log entries from session restorations, and much more.
 
-**Version 6.0.0** introduces major enhancements including session restoration prevention, improved device fingerprinting, enhanced statistics, and more. See the [Release Notes](RELEASE_NOTES.md) for complete details.
+**Version 6.0.0** introduces major enhancements including session restoration prevention, improved device fingerprinting, enhanced statistics, and more. **Version 6.1.0** adds Laravel 13.x support and compatibility with immutable date casting. See the [Release Notes](RELEASE_NOTES.md) for complete details.
 
 ## Features
 
@@ -87,8 +87,8 @@ php artisan migrate
 **Important:** If upgrading from v3.x or earlier, the upgrade migration will safely add the new columns (`device_id`, `device_name`, `is_trusted`, `last_activity_at`, `is_suspicious`, `suspicious_reason`) to your existing `authentication_log` table without affecting existing data.
 
 **Breaking Changes in v6.0.0:**
-- Laravel 10.x support has been dropped (only Laravel 11.x and 12.x are supported)
-- PHP 8.1+ is now required
+- Laravel 10.x support was dropped (v6.1+ supports Laravel 11.x, 12.x, and 13.x)
+- PHP 8.1+ was required (PHP 8.2+ as of v6.1.0)
 - See the [Upgrade Guide](docs/start/upgrade.md) for detailed migration instructions
 
 ### 3. Configure (Optional)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,20 @@
-# Laravel Authentication Log v6.0.0 Release Notes
+# Laravel Authentication Log Release Notes
+
+# v6.1.0 Release Notes
+
+## 🚀 Laravel 13 Support & Immutable Date Compatibility
+
+Released 2026-06-10.
+
+- **Laravel 13.x support** ([#140](https://github.com/rappasoft/laravel-authentication-log/pull/140)) — the package and CI matrix now cover PHP 8.2–8.4 on Laravel 11.x, 12.x, and 13.x
+- **Immutable date casting compatibility** ([#137](https://github.com/rappasoft/laravel-authentication-log/pull/137)) — `lastLoginAt()`, `lastSuccessfulLoginAt()`, and `previousLoginAt()` now return `\Carbon\CarbonInterface` instead of `\Illuminate\Support\Carbon`, fixing a `TypeError` in applications that cast model dates to `CarbonImmutable` (the default in current Laravel starter kits)
+- **PHP 8.2+ now required** — PHP 8.1 is EOL and was never installable alongside Laravel 11+, so this does not affect any working installation
+
+No database changes or migrations are required when upgrading from v6.0.x.
+
+---
+
+# v6.0.0 Release Notes
 
 ## 🎉 Major Release - Enhanced Features & Modernization
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -50,7 +50,7 @@ The following columns will be added to your `authentication_log` table:
 
 ### Requirements
 
-**Version 6.x requires Laravel 11.x or 12.x.**
+**Version 6.x requires Laravel 11.x, 12.x, or 13.x.** (Laravel 13.x support requires version 6.1+ and PHP 8.2+.)
 
 If you're still using Laravel 10.x, please continue using version 5.x of this package.
 
@@ -76,7 +76,7 @@ This is expected. Only new authentication logs will have device fingerprints. Ex
 
 **Issue: Features not working after upgrade**
 
-- Ensure you're running Laravel 11.x or 12.x for new features
+- Ensure you're running Laravel 11.x, 12.x, or 13.x for new features
 - Check that migrations ran successfully: `php artisan migrate:status`
 - Clear config cache: `php artisan config:clear`
 


### PR DESCRIPTION
Updates the remaining documentation for Laravel 13 support and v6.1.0: UPGRADE.md version requirements, README intro and historical v6.0.0 notes, and a v6.1.0 section in RELEASE_NOTES.md. Docs-only — no code changes, no new release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)