### PR TITLE
Fix session-restoration window: anchor on last_activity_at, not login_at

### DIFF
--- a/src/Listeners/LoginListener.php
+++ b/src/Listeners/LoginListener.php
@@ -60,11 +60,17 @@ class LoginListener
             $isSessionRestoration = false;
             if (config('authentication-log.prevent_session_restoration_logging', true)) {
                 $restorationWindow = config('authentication-log.session_restoration_window_minutes', 5);
+                // Measure the window against the session's most recent activity, not its
+                // original login_at. last_activity_at is bumped on every restoration below,
+                // so anchoring the lookup on login_at made a continuously-active session
+                // "age out" of the window and spawn a brand-new log row every
+                // $restorationWindow minutes for as long as the user stayed active.
                 $existingActiveSession = $user->authentications()
                     ->fromDevice($deviceId)
                     ->successful()
                     ->whereNull('logout_at')
-                    ->where('login_at', '>', now()->subMinutes($restorationWindow))
+                    ->where('last_activity_at', '>', now()->subMinutes($restorationWindow))
+                    ->orderByDesc('last_activity_at')
                     ->first();
 
                 if ($existingActiveSession) {

--- a/tests/Feature/SessionRestorationTest.php
+++ b/tests/Feature/SessionRestorationTest.php
@@ -66,6 +66,36 @@ it('creates new log entry if session restoration prevention is disabled', functi
     expect($afterRestorationCount)->toBe(2);
 });
 
+it('keeps one log entry for a session that stays active past its original login window', function () {
+    config(['authentication-log.prevent_session_restoration_logging' => true]);
+    config(['authentication-log.session_restoration_window_minutes' => 5]);
+
+    $user = TestUser::factory()->create();
+
+    request()->server->set('REMOTE_ADDR', '192.168.1.1');
+    request()->headers->set('User-Agent', 'Test Browser');
+
+    Event::dispatch(new Login('web', $user, false));
+    expect(AuthenticationLog::where('authenticatable_id', $user->id)->count())->toBe(1);
+
+    // The session has been active for ~6 minutes: its original login_at is now
+    // older than the 5-minute window, but restorations kept last_activity_at fresh.
+    // Anchoring the lookup on login_at (the bug) would spawn a second row here.
+    $log = AuthenticationLog::where('authenticatable_id', $user->id)->first();
+    $log->update([
+        'login_at' => now()->subMinutes(6),
+        'last_activity_at' => now()->subMinute(),
+    ]);
+
+    Event::dispatch(new Login('web', $user, false));
+
+    // Still one entry — the active session is recognized via last_activity_at.
+    expect(AuthenticationLog::where('authenticatable_id', $user->id)->count())->toBe(1);
+
+    $log->refresh();
+    expect($log->last_activity_at->timestamp)->toBeGreaterThan(now()->subMinute()->timestamp);
+});
+
 it('creates new log entry if existing session is outside restoration window', function () {
     config(['authentication-log.prevent_session_restoration_logging' => true]);
     config(['authentication-log.session_restoration_window_minutes' => 5]);
@@ -76,7 +106,7 @@ it('creates new log entry if existing session is outside restoration window', fu
     request()->server->set('REMOTE_ADDR', '192.168.1.1');
     request()->headers->set('User-Agent', 'Test Browser');
 
-    // Create an old login (outside the window)
+    // Create an old session whose last activity is outside the window
     $oldLog = AuthenticationLog::factory()->create([
         'authenticatable_type' => get_class($user),
         'authenticatable_id' => $user->id,
@@ -84,6 +114,7 @@ it('creates new log entry if existing session is outside restoration window', fu
         'login_at' => now()->subMinutes(10),
         'login_successful' => true,
         'logout_at' => null,
+        'last_activity_at' => now()->subMinutes(10),
     ]);
 
     $initialCount = AuthenticationLog::where('authenticatable_id', $user->id)->count();
@@ -166,9 +197,9 @@ it('respects configurable restoration window', function () {
     $initialCount = AuthenticationLog::where('authenticatable_id', $user->id)->count();
     expect($initialCount)->toBe(1);
 
-    // Create an old login (outside the 1-minute window)
+    // Age the session's last activity outside the 1-minute window
     $oldLog = AuthenticationLog::where('authenticatable_id', $user->id)->first();
-    $oldLog->update(['login_at' => now()->subMinutes(2)]);
+    $oldLog->update(['login_at' => now()->subMinutes(2), 'last_activity_at' => now()->subMinutes(2)]);
 
     // New login (outside 1-minute window) - should create new entry
     Event::dispatch(new Login('web', $user, false));

--- a/tests/Feature/SuspiciousActivityNotificationTest.php
+++ b/tests/Feature/SuspiciousActivityNotificationTest.php
@@ -107,6 +107,9 @@ it('sends notification for rapid location changes during login', function () {
         'authenticatable_id' => $user->id,
         'login_successful' => true,
         'login_at' => now()->subMinutes(30),
+        // Pin last activity outside the restoration window — the factory randomizes
+        // it, and a recent value would make the login below a session restoration.
+        'last_activity_at' => now()->subMinutes(30),
         'ip_address' => $sameIp,
         'user_agent' => $sameUserAgent,
         'device_id' => $deviceId,
@@ -123,6 +126,7 @@ it('sends notification for rapid location changes during login', function () {
         'authenticatable_id' => $user->id,
         'login_successful' => true,
         'login_at' => now()->subMinutes(20),
+        'last_activity_at' => now()->subMinutes(20),
         'ip_address' => $sameIp,
         'user_agent' => $sameUserAgent,
         'device_id' => $deviceId,
@@ -173,6 +177,9 @@ it('sends notification for unusual login times when enabled', function () {
         'authenticatable_id' => $user->id,
         'login_successful' => true,
         'login_at' => $testTime->copy()->subMinutes(30),
+        // Pin last activity outside the restoration window — the factory randomizes
+        // it, and a recent value would make the login below a session restoration.
+        'last_activity_at' => $testTime->copy()->subMinutes(30),
         'ip_address' => $sameIp,
         'user_agent' => $sameUserAgent,
         'device_id' => $deviceId,
@@ -220,6 +227,9 @@ it('does not send notification for unusual login times when check is disabled', 
         'authenticatable_id' => $user->id,
         'login_successful' => true,
         'login_at' => $testTime->copy()->subMinutes(30),
+        // Pin last activity outside the restoration window — the factory randomizes
+        // it, and a recent value would make the login below a session restoration.
+        'last_activity_at' => $testTime->copy()->subMinutes(30),
         'ip_address' => $sameIp,
         'user_agent' => $sameUserAgent,
         'device_id' => $deviceId,
@@ -385,6 +395,9 @@ it('does not send notification for rapid location change when locations are same
         'authenticatable_id' => $user->id,
         'login_successful' => true,
         'login_at' => now()->subMinutes(30),
+        // Pin last activity outside the restoration window — the factory randomizes
+        // it, and a recent value would make the login below a session restoration.
+        'last_activity_at' => now()->subMinutes(30),
         'ip_address' => $sameIp,
         'user_agent' => $sameUserAgent,
         'device_id' => $deviceId,
@@ -401,6 +414,7 @@ it('does not send notification for rapid location change when locations are same
         'authenticatable_id' => $user->id,
         'login_successful' => true,
         'login_at' => now()->subMinutes(20),
+        'last_activity_at' => now()->subMinutes(20),
         'ip_address' => $sameIp,
         'user_agent' => $sameUserAgent,
         'device_id' => $deviceId,


### PR DESCRIPTION
## Problem

The session-restoration prevention added in v6.0.0 keeps an active session from creating duplicate log entries by updating `last_activity_at` instead of inserting a new row. However, it looks the active session up by **`login_at`**:

```php
$existingActiveSession = $user->authentications()
    ->fromDevice($deviceId)
    ->successful()
    ->whereNull('logout_at')
    ->where('login_at', '>', now()->subMinutes($restorationWindow))
    ->first();

if ($existingActiveSession) {
    $existingActiveSession->update(['last_activity_at' => now()]); // keeps last_activity_at fresh...
    $isSessionRestoration = true;
}
```

Because the lookup is anchored on `login_at`, the `last_activity_at` it maintains is never actually used to decide whether the session is still active. Once a session's original `login_at` is older than `session_restoration_window_minutes`, a **continuously active** session (page refreshes, polling, remember-me, crawlers hitting authenticated URLs) is no longer matched, so a brand-new log entry is created — and then another every window after that, for as long as activity continues.

The result is long chains of duplicate login rows spaced exactly one restoration window apart for a single real session.

## Fix

Look the active session up by **`last_activity_at`** — the value the restoration path already maintains — so an active session keeps extending the same row no matter how long it runs:

```php
->whereNull('logout_at')
->where('last_activity_at', '>', now()->subMinutes($restorationWindow))
->orderByDesc('last_activity_at')
->first();
```

`last_activity_at` is always populated on creation (`'last_activity_at' => now()`), so this is a safe swap.

## Tests

- Added a regression test: a session active past its original `login_at` window stays a single row.
- Updated two existing tests that aged `login_at` to age `last_activity_at` instead (the value the check now uses).

All `SessionRestorationTest` cases pass; the new regression test fails on the previous `login_at`-anchored logic and passes on the fix.